### PR TITLE
state-dump: fix commit

### DIFF
--- a/src/dump-generation/state-dump.ts
+++ b/src/dump-generation/state-dump.ts
@@ -58,4 +58,11 @@ export const importHardhatStateDump = async (
 
     await (node as any)._saveBlockAsSuccessfullyRun(parsedBlock, result)
   }
+
+  await new Promise<void>(resolve => {
+    node._stateManager.commit(() => {
+      console.log('Initial state import complete')
+      resolve()
+    })
+  })
 }


### PR DESCRIPTION
This fixes a bug where the imported state needs to be committed before methods are allowed to be called. Currently, rpc requests will fail due to this error: https://github.com/nomiclabs/ethereumjs-vm/blob/c4aba3186883bf88839c14dbe775eaf443232633/lib/state/stateManager.ts#L416

In the process of testing this out locally to make sure that it works fully